### PR TITLE
fix: use secure protocol when endpoint is unspecified

### DIFF
--- a/src/fc-client/index.ts
+++ b/src/fc-client/index.ts
@@ -69,6 +69,6 @@ export async function makeFcClient(props: MakeFcClientInput) {
     region,
     timeout,
     endpoint,
-	secure: true,
+    secure: true,
   });
 }


### PR DESCRIPTION
https://github.com/devsapp/fc-core/blob/75db3c3b89255b6745171f355f1aa2f5b7bac1e9/src/fc-client/index.ts#L65-L72
使用serverless-dev的`s deploy`时，这里的endpoint固定是http，无法配置，更新函数会泄漏环境变量

![image](https://user-images.githubusercontent.com/12658348/235310421-f4f10806-e2d3-42b5-9808-a281dfffcdef.png)
